### PR TITLE
fix test failures on big-endian systems

### DIFF
--- a/cbits/gf.c
+++ b/cbits/gf.c
@@ -64,9 +64,9 @@ void gf_mul(block128 *a, block128 *b)
 /* inplace GFMUL for xts mode */
 void gf_mulx(block128 *a)
 {
-	const uint64_t gf_mask = 0x8000000000000000ULL;
-	uint64_t r = ((a->q[1] & gf_mask) ? 0x87 : 0);
-	a->q[1] = (a->q[1] << 1) | (a->q[0] & gf_mask ? 1 : 0);
-	a->q[0] = (a->q[0] << 1) ^ r;
+	const uint64_t gf_mask = cpu_to_le64(0x8000000000000000ULL);
+	uint64_t r = ((a->q[1] & gf_mask) ? cpu_to_le64(0x87) : 0);
+	a->q[1] = cpu_to_le64((le64_to_cpu(a->q[1]) << 1) | (a->q[0] & gf_mask ? 1 : 0));
+	a->q[0] = cpu_to_le64(le64_to_cpu(a->q[0]) << 1) ^ r;
 }
 


### PR DESCRIPTION
This fixes test failures on big-endian systems.  You can see failing test output here:

  https://launchpadlibrarian.net/134964454/buildlog_ubuntu-raring-powerpc.haskell-cipher-aes_0.1.7-1_FAILEDTOBUILD.txt.gz

I've tested this on the current Ubuntu development branch, on both i386 and powerpc.
