### PR TITLE
Re-enable Mac OS X support

### DIFF
--- a/cipher-aes.cabal
+++ b/cipher-aes.cabal
@@ -38,7 +38,7 @@ Library
                      cbits/aes.c
                      cbits/gf.c
                      cbits/cpu.c
-  if os(linux) && (arch(i386) || arch(x86_64))
+  if (os(linux) || os(darwin)) && (arch(i386) || arch(x86_64))
     CC-options:      -mssse3 -maes -mpclmul -DWITH_AESNI
     C-sources:       cbits/aes_x86ni.c
 


### PR DESCRIPTION
x86-Darwin presents the same special case as x86-Linux.
