### PR TITLE
Bump securemem to 0.1.3 to fix compilation on ghc 7.4

### DIFF
--- a/cipher-aes.cabal
+++ b/cipher-aes.cabal
@@ -35,7 +35,7 @@ Library
                    , bytestring
                    , byteable
                    , crypto-cipher-types >= 0.0.3
-                   , securemem >= 0.1.2
+                   , securemem >= 0.1.3
   Exposed-modules:   Crypto.Cipher.AES
   ghc-options:       -Wall -optc-O3 -fno-cse -fwarn-tabs
   C-sources:         cbits/aes_generic.c


### PR DESCRIPTION
fixed securemem ticket: https://github.com/vincenthz/hs-securemem/issues/2
