### PR TITLE
Added case to check for ECB encryption on empty strings.

### DIFF
--- a/Crypto/Cipher/AES.hs
+++ b/Crypto/Cipher/AES.hs
@@ -243,6 +243,7 @@ decryptGCM = doGCM gcmAppendDecrypt
 doECB :: (Ptr b -> Ptr AES -> CString -> CUInt -> IO ())
       -> AES -> ByteString -> ByteString
 doECB f ctx input
+    | len == 0  = B.empty
     | r /= 0    = error "cannot use with non multiple of block size"
     | otherwise = unsafeCreate len $ \o ->
                   keyToPtr ctx $ \k ->


### PR DESCRIPTION
Encrypting an empty string in ECB mode causes a divide by zero error. This is a bit more helpful.
